### PR TITLE
Task #PS-710 Cohort member search API - If API enpoint has ?fieldValues=true, then only pass the fieldValues in the response

### DIFF
--- a/src/adapters/cohortMembersservicelocator.ts
+++ b/src/adapters/cohortMembersservicelocator.ts
@@ -10,7 +10,7 @@ export interface IServicelocatorcohortMembers {
     tenantId: string,
   );
   getCohortMembers(cohortMemberId: string, tenantId: string, fieldvalue: string, response: Response);
-  searchCohortMembers(cohortMembersSearchDto: CohortMembersSearchDto, tenantId: string, response: Response);
+  searchCohortMembers(cohortMembersSearchDto: CohortMembersSearchDto, fieldvalue: boolean, tenantId: string, response: Response);
   updateCohortMembers(
     cohortMembershipId: string,
     loginUser: any,

--- a/src/adapters/hasura/cohortMembers.adapter.ts
+++ b/src/adapters/hasura/cohortMembers.adapter.ts
@@ -10,9 +10,8 @@ import { CohortMembersUpdateDto } from "src/cohortMembers/dto/cohortMember-updat
 
 @Injectable()
 export class HasuraCohortMembersService
-  implements IServicelocatorcohortMembers
-{
-  constructor(private httpService: HttpService) {}
+  implements IServicelocatorcohortMembers {
+  constructor(private httpService: HttpService) { }
 
   public async createCohortMembers(
     request: any,
@@ -75,8 +74,8 @@ export class HasuraCohortMembersService
     }
   }
 
-  public async searchCohortMembers(cohortMembersSearchDto, tenantId, res) {}
-  public async getCohortMembers(cohortMemberId, tenantId, fieldvalue, res) {}
+  public async searchCohortMembers(cohortMembersSearchDto, fieldvalue, tenantId, res) { }
+  public async getCohortMembers(cohortMemberId, tenantId, fieldvalue, res) { }
   public async updateCohortMembers(
     cohortMembershipId: string,
     request: any,
@@ -106,5 +105,5 @@ export class HasuraCohortMembersService
     return cohortMembersResponse;
   }
 
-  public async deleteCohortMemberById() {}
+  public async deleteCohortMemberById() { }
 }

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -167,6 +167,7 @@ export class PostgresCohortMembersService {
 
   public async searchCohortMembers(
     cohortMembersSearchDto: CohortMembersSearchDto,
+    fieldvalue: boolean,
     tenantId: string,
     res: Response
   ) {
@@ -244,7 +245,7 @@ export class PostgresCohortMembersService {
 
       results = await this.getCohortMemberUserDetails(
         where,
-        "true",
+        fieldvalue,
         options
       );
       if (results == false) {
@@ -266,7 +267,7 @@ export class PostgresCohortMembersService {
     }
   }
 
-  async getCohortMemberUserDetails(where: any, fieldShowHide: any, options: any) {
+  async getCohortMemberUserDetails(where: any, fieldShowHide: boolean, options: any) {
     let results = {
       userDetails: [],
     };
@@ -285,11 +286,11 @@ export class PostgresCohortMembersService {
           mobile: data?.mobile
         };
 
-        if (fieldShowHide === "false") {
-          results.userDetails.push(userDetails);
-        } else {
+        if (fieldShowHide == true) {
           const fieldValues = await this.getFieldandFieldValues(data.userId);
           userDetails['customField'] = fieldValues;
+          results.userDetails.push(userDetails);
+        } else {
           results.userDetails.push(userDetails);
         }
       }

--- a/src/cohortMembers/cohortMembers.controller.ts
+++ b/src/cohortMembers/cohortMembers.controller.ts
@@ -34,7 +34,7 @@ import { CohortMembersDto } from "./dto/cohortMembers.dto";
 import { CohortMembersAdapter } from "./cohortMembersadapter";
 import { CohortMembersUpdateDto } from "./dto/cohortMember-update.dto";
 import { JwtAuthGuard } from "src/common/guards/keycloak.guard";
-import { Response } from "express";
+import { Response, query } from "express";
 import { AllExceptionsFilter } from "src/common/filters/exception.filter";
 import { APIID } from "src/common/utils/api-id.config";
 
@@ -113,17 +113,24 @@ export class CohortMembersController {
   @ApiHeader({
     name: "tenantid",
   })
+  @ApiQuery({
+    name: "fieldvalue",
+    description: "Send True to Fetch Custom Field of User",
+    required: false,
+  })
   public async searchCohortMembers(
     @Headers() headers,
     @Req() request: Request,
     @Res() response: Response,
-    @Body() cohortMembersSearchDto: CohortMembersSearchDto
+    @Body() cohortMembersSearchDto: CohortMembersSearchDto,
+    @Query("fieldvalue") fieldvalue: boolean | null = null
   ) {
     const tenantId = headers["tenantid"];
+    const finalFieldValue = fieldvalue !== null ? fieldvalue : false;
 
     const result = await this.cohortMemberAdapter
       .buildCohortMembersAdapter()
-      .searchCohortMembers(cohortMembersSearchDto, tenantId, response);
+      .searchCohortMembers(cohortMembersSearchDto, finalFieldValue, tenantId, response);
   }
 
   //update

--- a/src/cohortMembers/cohortMembers.module.ts
+++ b/src/cohortMembers/cohortMembers.module.ts
@@ -11,10 +11,11 @@ import { HasuraCohortMembersService } from "src/adapters/hasura/cohortMembers.ad
 import { Fields } from "src/fields/entities/fields.entity";
 import { User } from "src/user/entities/user-entity";
 import { Cohort } from "src/cohort/entities/cohort.entity";
+import { Role } from "src/rbac/role/entities/role.entity";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([CohortMembers, Fields, User, Cohort]),
+    TypeOrmModule.forFeature([CohortMembers, Fields, User, Cohort, Role]),
     HttpModule,
     HasuraModule,
     PostgresModule,

--- a/src/cohortMembers/dto/cohortMembers-search.dto.ts
+++ b/src/cohortMembers/dto/cohortMembers-search.dto.ts
@@ -9,14 +9,14 @@ export class CohortMembersSearchDto {
 
   @ApiProperty({
     type: Number,
-    description: "Page",
+    description: "Offset",
   })
-  page: number;
+  offset: number;
 
   @ApiProperty({
     type: Object,
     description: "Filters",
-    example: { cohortId: "", userId: "", role:"" }, // Adding example for Swagger
+    example: { cohortId: "", userId: "", role: "" }, // Adding example for Swagger
   })
   @ApiPropertyOptional()
   filters: { cohortId?: string; userId?: string; role?: string }; // Define cohortId and userId properties


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch custom fields of a user with a new `fieldvalue` parameter in cohort member searches.

- **Improvements**
  - Enhanced cohort member search to include a `fieldvalue` parameter for better filtering.
  - Renamed `page` to `offset` in search DTO for clarity.

- **Documentation**
  - Updated Swagger documentation with new examples for cohort member search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->